### PR TITLE
Fix C++ standard for esp-idf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,5 @@ idf_component_register(
 )
 
 # (optional) clip the C++ standard or extra flags
-target_compile_options(${COMPONENT_LIB} PRIVATE -std=gnu++23)
+# Use C++17 for compatibility with ESP-IDF toolchains
+target_compile_options(${COMPONENT_LIB} PRIVATE -std=gnu++17)


### PR DESCRIPTION
## Summary
- lower the C++ standard to gnu++17 so the driver builds on esp-idf toolchains

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c46577ef08328aefe29d6cc816fb8