### PR TITLE
Fix missing RMT types include

### DIFF
--- a/src/rmt_wrapper.cpp
+++ b/src/rmt_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "rmt_wrapper.hpp"
+#include "driver/rmt_types.h"
 
 #ifdef __cplusplus
 

--- a/src/ws2812_control.c
+++ b/src/ws2812_control.c
@@ -1,5 +1,6 @@
 #include "ws2812_control.h"
 #include "driver/rmt_tx.h"
+#include "driver/rmt_types.h"
 #include "led_strip_encoder.h"
 #include "esp_err.h"
 #include "esp_check.h"

--- a/src/ws2812_cpp.cpp
+++ b/src/ws2812_cpp.cpp
@@ -1,4 +1,5 @@
 #include "ws2812_cpp.hpp"
+#include "driver/rmt_types.h"
 
 #ifdef __cplusplus
 

--- a/src/ws2812_effects.cpp
+++ b/src/ws2812_effects.cpp
@@ -1,4 +1,5 @@
 #include "ws2812_effects.hpp"
+#include "driver/rmt_types.h"
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
## Summary
- include `driver/rmt_types.h` in source files using `rmt_channel_t` and `rmt_item32_t`
