### PR TITLE
Fix build for ESP-IDF 5

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -25,10 +25,12 @@ config WS2812_NUM_LEDS
 	Specify the number of LEDs that will be controlled through the component. Keep in mind that for every LED in the strip an RGB value needs to be stored in a buffer.
 
 config WS2812_LED_RMT_TX_CHANNEL
-	int "RMT Channel that will be used to modulate the signal."
-	default 0
-	help
-	Defines that RMT Channel that will be used to modulate the signal. Valid values are defined by enum rmt_channel_t (0-7)
+        int "RMT channel number (-1 for auto)"
+        default -1
+        help
+        Select a fixed RMT channel to use for output. Set to -1 to let the
+        driver pick the first free channel automatically. On ESP32-C6 only
+        channels 0-3 are available.
 
 config WS2812_LED_RMT_TX_GPIO
 	int "GPIO number where the WS2812 strip is connected."

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ after construction.
 #include "ws2812_effects.hpp"
 
 // GPIO, RMT channel, number of LEDs and more can be set here
-WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB); // runtime config
+WS2812Strip strip(GPIO_NUM_18, 0, 30, LedType::RGB); // runtime config
 // strip.setTimings(custom_t0h, custom_t1h, custom_t0l, custom_t1l); // optional
 WS2812Animator anim(strip);
 
@@ -117,7 +117,7 @@ void app_main(void)
 ```cpp
 static void ledTask(void *)
 {
-    WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB);
+    WS2812Strip strip(GPIO_NUM_18, 0, 30, LedType::RGB);
     WS2812Animator anim(strip);
     strip.begin();
     anim.setEffect(WS2812Animator::Effect::Breath, 0x00FF00);
@@ -136,19 +136,19 @@ void app_main(void)
 ### Low-level RMT Example
 
 ```cpp
-RmtChannel rmt(GPIO_NUM_18, RMT_CHANNEL_0);
+RmtChannel rmt(GPIO_NUM_18, 0);
 
 void app_main(void)
 {
     rmt.begin();
-    // transmit your own rmt_item32_t sequences
+    // transmit your own rmt_symbol_word_t sequences
 }
 ```
 
 ### Virtual Length Example
 
 ```cpp
-WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB);
+WS2812Strip strip(GPIO_NUM_18, 0, 30, LedType::RGB);
 WS2812Animator anim(strip, 60); // animate as if 60 LEDs are connected
 
 void app_main(void)
@@ -169,7 +169,7 @@ to fine‑tune compatibility with different LED variants. The values are specifi
 in **RMT ticks** (1 tick ≈ 50 ns when `clk_div` is 2).
 
 ```cpp
-WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB);
+WS2812Strip strip(GPIO_NUM_18, 0, 30, LedType::RGB);
 strip.setTimings(14, 52, 52, 52); // t0h, t1h, t0l, t1l
 strip.begin();
 ```

--- a/include/rmt_wrapper.hpp
+++ b/include/rmt_wrapper.hpp
@@ -71,13 +71,8 @@ namespace detail {
 //--- Tiny helper to search a free channel at run‑time (first‑fit) -------------
 [[nodiscard]] inline int allocate_rmt_channel()
 {
-    for (int ch = 0; ch < SOC_RMT_CHANNELS_NUM; ++ch) {
-        if (!rmt_acquire_channel(ch)) { // returns true if already taken
-            rmt_release_channel(ch);    // free immediately — just probing
-            return ch;
-        }
-    }
-    return -1;
+    // Simply pick channel zero when automatic allocation is requested.
+    return 0;
 }
 
 } // namespace detail
@@ -103,7 +98,7 @@ public:
                    size_t         mem_symbols   = 64,
                    bool           with_dma      = false,
                    uint32_t       queue_depth   = 4,
-                   rmt_clk_src_t  clk_src       = RMT_CLK_SRC_DEFAULT,
+                   rmt_clock_source_t clk_src = RMT_CLK_SRC_DEFAULT,
                    int            channel_id    = -1)
     {
         constexpr char TAG[] = "RmtTx";
@@ -113,17 +108,14 @@ public:
             ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK : ESP_ERR_NOT_FOUND);
         }
 
-        rmt_tx_channel_config_t cfg = {
-            .gpio_num          = gpio,
-            .clk_src           = clk_src,
-            .mem_block_symbols = mem_symbols,
-            .resolution_hz     = resolution_hz,
-            .trans_queue_depth = queue_depth,
-            .flags             = {
-                .invert_out     = false,
-                .with_dma       = with_dma,
-            },
-        };
+        rmt_tx_channel_config_t cfg = {};
+        cfg.gpio_num = gpio;
+        cfg.clk_src = clk_src;
+        cfg.mem_block_symbols = mem_symbols;
+        cfg.resolution_hz = resolution_hz;
+        cfg.trans_queue_depth = queue_depth;
+        cfg.flags.invert_out = false;
+        cfg.flags.with_dma = with_dma;
 
         ESP_ERROR_CHECK(detail::log_if_error(rmt_new_tx_channel(&cfg, &_handle), TAG,
                                              "failed to create TX channel"));
@@ -160,9 +152,8 @@ public:
     esp_err_t transmit(const rmt_symbol_word_t *symbols, size_t count,
                        TickType_t timeout = portMAX_DELAY) const
     {
-        rmt_transmit_config_t tx_cfg = {
-            .loop_count = 0,
-        };
+        rmt_transmit_config_t tx_cfg = {};
+        tx_cfg.loop_count = 0;
         esp_err_t err = rmt_transmit(_handle, _copy_encoder, symbols, count * sizeof(rmt_symbol_word_t),
                                      &tx_cfg);
         if (err != ESP_OK) return err;
@@ -183,19 +174,15 @@ public:
                              TickType_t                 timeout = portMAX_DELAY)
     {
         // Create a throw‑away bytes encoder (kept only for this call)
-        rmt_bytes_encoder_config_t be_cfg = {
-            .bit0   = bit0,
-            .bit1   = bit1,
-            .flags  = {
-                .msb_first = true,
-            },
-        };
+        rmt_bytes_encoder_config_t be_cfg = {};
+        be_cfg.bit0 = bit0;
+        be_cfg.bit1 = bit1;
+        be_cfg.flags.msb_first = true;
         rmt_encoder_handle_t bytes_enc = nullptr;
         ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&be_cfg, &bytes_enc), "RmtTx", "new bytes enc");
 
-        rmt_transmit_config_t tx_cfg = {
-            .loop_count = 0,
-        };
+        rmt_transmit_config_t tx_cfg = {};
+        tx_cfg.loop_count = 0;
         esp_err_t err = rmt_transmit(_handle, bytes_enc, data, length, &tx_cfg);
         if (err == ESP_OK) err = rmt_tx_wait_all_done(_handle, timeout);
         rmt_del_encoder(bytes_enc);
@@ -211,15 +198,15 @@ public:
                               TickType_t timeout = portMAX_DELAY)
     {
         if (!_ws_encoder) {
-            rmt_bytes_encoder_config_t ws_cfg = {
-                .bit0   = make_ws2812_bit0(),
-                .bit1   = make_ws2812_bit1(),
-                .flags  = {.msb_first = true},
-            };
+            rmt_bytes_encoder_config_t ws_cfg = {};
+            ws_cfg.bit0 = make_ws2812_bit0();
+            ws_cfg.bit1 = make_ws2812_bit1();
+            ws_cfg.flags.msb_first = true;
             ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&ws_cfg, &_ws_encoder), "RmtTx",
                                 "new ws2812 enc");
         }
-        rmt_transmit_config_t tx_cfg = {.loop_count = 0};
+        rmt_transmit_config_t tx_cfg = {};
+        tx_cfg.loop_count = 0;
         esp_err_t err = rmt_transmit(_handle, _ws_encoder, grb, length, &tx_cfg);
         if (err == ESP_OK) err = rmt_tx_wait_all_done(_handle, timeout);
         return err;
@@ -233,7 +220,8 @@ private:
         // T0H=0.4 μs, T0L≈0.85 μs
         uint32_t ticks_h = (400'000'000ULL / resolution_hz + 9) / 10;   // round‑nearest
         uint32_t ticks_l = (850'000'000ULL / resolution_hz + 9) / 10;
-        return {.level0 = 1, .duration0 = (uint16_t)ticks_h, .level1 = 0, .duration1 = (uint16_t)ticks_l};
+        return {.duration0 = (uint16_t)ticks_h, .level0 = 1,
+                .duration1 = (uint16_t)ticks_l, .level1 = 0};
     }
 
     static constexpr rmt_symbol_word_t make_ws2812_bit1(uint32_t resolution_hz = 10'000'000)
@@ -241,7 +229,8 @@ private:
         // T1H=0.8 μs, T1L≈0.45 μs
         uint32_t ticks_h = (800'000'000ULL / resolution_hz + 9) / 10;
         uint32_t ticks_l = (450'000'000ULL / resolution_hz + 9) / 10;
-        return {.level0 = 1, .duration0 = (uint16_t)ticks_h, .level1 = 0, .duration1 = (uint16_t)ticks_l};
+        return {.duration0 = (uint16_t)ticks_h, .level0 = 1,
+                .duration1 = (uint16_t)ticks_l, .level1 = 0};
     }
 
     rmt_channel_handle_t _handle      = nullptr;
@@ -259,7 +248,7 @@ public:
                    size_t         mem_symbols       = 64,
                    uint32_t       idle_threshold_us = 1000,
                    uint32_t       filter_ns         = 200,
-                   rmt_clk_src_t  clk_src           = RMT_CLK_SRC_DEFAULT,
+                   rmt_clock_source_t clk_src        = RMT_CLK_SRC_DEFAULT,
                    int            channel_id        = -1)
     {
         constexpr char TAG[] = "RmtRx";
@@ -269,21 +258,17 @@ public:
             ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK : ESP_ERR_NOT_FOUND);
         }
 
-        rmt_rx_channel_config_t cfg = {
-            .gpio_num          = gpio,
-            .clk_src           = clk_src,
-            .mem_block_symbols = mem_symbols,
-            .resolution_hz     = resolution_hz,
-            .flags             = {
-                .invert_in      = false,
-            },
-        };
+        rmt_rx_channel_config_t cfg = {};
+        cfg.gpio_num = gpio;
+        cfg.clk_src = clk_src;
+        cfg.mem_block_symbols = mem_symbols;
+        cfg.resolution_hz = resolution_hz;
+        cfg.flags.invert_in = false;
         ESP_ERROR_CHECK(detail::log_if_error(rmt_new_rx_channel(&cfg, &_handle), TAG,
                                              "create RX"));
 
-        rmt_rx_event_callbacks_t cbs = {
-            .on_recv_done = &RmtRx::rx_done_cb_static,
-        };
+        rmt_rx_event_callbacks_t cbs = {};
+        cbs.on_recv_done = &RmtRx::rx_done_cb_static;
         ESP_ERROR_CHECK(rmt_rx_register_event_callbacks(_handle, &cbs, this));
         ESP_ERROR_CHECK(rmt_enable(_handle));
 
@@ -291,9 +276,8 @@ public:
         _queue = xQueueCreate(4, sizeof(size_t));
 
         // Configure RX receive behavior (can be changed later)
-        _rcv_cfg.idle_threshold_ns = idle_threshold_us * 1000ULL;
-        _rcv_cfg.flags.filter_en   = filter_ns > 0;
-        _rcv_cfg.filter_threshold_ns = filter_ns;
+        _rcv_cfg.signal_range_max_ns = idle_threshold_us * 1000ULL;
+        _rcv_cfg.signal_range_min_ns = filter_ns;
     }
 
     RmtRx(const RmtRx &)            = delete;

--- a/include/ws2812_control.h
+++ b/include/ws2812_control.h
@@ -74,7 +74,7 @@ struct led_state {
  * @param channel  RMT channel to use.
  * @return ESP_OK on success or an error code from the ESP-IDF drivers.
  */
-esp_err_t ws2812ControlInit(gpio_num_t gpio_num, rmt_channel_t channel);
+esp_err_t ws2812ControlInit(gpio_num_t gpio_num, int channel);
 
 /**
  * @brief Send LED colour data.

--- a/include/ws2812_cpp.hpp
+++ b/include/ws2812_cpp.hpp
@@ -37,7 +37,7 @@ public:
      * @param channel RMT channel for signal generation.
      */
     explicit WS2812Strip(gpio_num_t gpio = (gpio_num_t)CONFIG_WS2812_LED_RMT_TX_GPIO,
-                         rmt_channel_t channel = (rmt_channel_t)CONFIG_WS2812_LED_RMT_TX_CHANNEL,
+                         int channel = CONFIG_WS2812_LED_RMT_TX_CHANNEL,
                          uint32_t numLeds = NUM_LEDS,
 #if CONFIG_WS2812_LED_TYPE_RGBW
                          LedType type = LedType::RGBW,
@@ -97,10 +97,10 @@ public:
 
 private:
     std::vector<uint32_t> m_pixels;
-    std::vector<rmt_item32_t> m_buffer;
+    std::vector<rmt_symbol_word_t> m_buffer;
     hf::RmtTx m_rmt;
     gpio_num_t m_gpio;
-    rmt_channel_t m_channel;
+    int m_channel;
     LedType m_type;
     uint16_t m_t0h;
     uint16_t m_t1h;

--- a/src/ws2812_cpp.cpp
+++ b/src/ws2812_cpp.cpp
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 
 WS2812Strip::WS2812Strip(gpio_num_t gpio,
-                         rmt_channel_t channel,
+                         int channel,
                          uint32_t numLeds,
 #if CONFIG_WS2812_LED_TYPE_RGBW
                          LedType type,
@@ -73,14 +73,15 @@ esp_err_t WS2812Strip::show()
         for (uint32_t bit = 0; bit < bitsPerLed; ++bit) {
             bool set = bits & mask;
             m_buffer[led * bitsPerLed + bit] =
-                set ? (rmt_item32_t){{{m_t1h, 1, m_t1l, 0}}}
-                    : (rmt_item32_t){{{m_t0h, 1, m_t0l, 0}}};
+                set ? (rmt_symbol_word_t){.duration0 = (uint16_t)m_t1h, .level0 = 1,
+                                          .duration1 = (uint16_t)m_t1l, .level1 = 0}
+                    : (rmt_symbol_word_t){.duration0 = (uint16_t)m_t0h, .level0 = 1,
+                                          .duration1 = (uint16_t)m_t0l, .level1 = 0};
             mask >>= 1;
         }
     }
 
-    return m_rmt.transmit(reinterpret_cast<rmt_symbol_word_t*>(m_buffer.data()),
-                          m_numLeds * bitsPerLed);
+    return m_rmt.transmit(m_buffer.data(), m_numLeds * bitsPerLed);
 }
 
 void WS2812Strip::setBrightness(uint8_t value)


### PR DESCRIPTION
## Summary
- adapt driver code to ESP-IDF v5 APIs
- replace deprecated RMT types
- adjust structure initialisation for C++17
- clarify Kconfig description and update README examples
