### PR TITLE
Fix example to use LedType enumeration

### DIFF
--- a/example/main/main.cpp
+++ b/example/main/main.cpp
@@ -1,6 +1,6 @@
 #include "ws2812_cpp.hpp"
 
 extern "C" void app_main(void) {
-  WS2812Strip strip(GPIO_NUM_1, 0, 1, WS2812Strip::LedType::RGB);
+  WS2812Strip strip(GPIO_NUM_1, 0, 1, LedType::RGB);
   (void)strip;
 }


### PR DESCRIPTION
## Summary
- update example to reference `LedType` directly instead of `WS2812Strip::LedType`
