### PR TITLE
Run CodeQL during build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          tools: latest
+          queries: +security-extended
+
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
@@ -70,6 +76,8 @@ jobs:
             ${{ env.BUILD_PATH }}/build/*.map
             ${{ env.BUILD_PATH }}/build/size.*
 
+      - uses: github/codeql-action/analyze@v3
+
   static-analysis:
     name: Static analyse (cppcheck + clang-tidy)
     runs-on: ubuntu-latest
@@ -93,21 +101,6 @@ jobs:
           config_file: .clang-tidy
           style: file
 
-  codeql:
-    name: CodeQL static scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: cpp
-          tools: latest
-          queries: +security-extended
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
 
   workflow-lint:
     name: actionlint


### PR DESCRIPTION
## Summary
- initialize CodeQL before building
- analyze the compiled project directly in the build job
- remove the separate CodeQL job
