### PR TITLE
Fix clang-tidy review on push builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           include: main
 
       - uses: ZedThree/clang-tidy-review@v0.21.0
+        if: github.event_name == 'pull_request'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config_file: .clang-tidy


### PR DESCRIPTION
## Summary
- ensure `clang-tidy-review` step only runs when triggered by a pull request

## Testing
- `clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684da2db9d0083288da64806602ef868