### PR TITLE
Restrict clang-tidy to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
 
 
   static-analysis:
+    if: github.event_name == 'pull_request'
     name: Static analyse (cppcheck + clang-tidy)
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary
- run clang-tidy job only when `github.event_name` equals `pull_request`
