### PR TITLE
Clean docs and ignore generated output

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: CI • Build · Size · Static Analyse · Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IDF_TARGET: esp32c6
+  BUILD_PATH: ci_project
+  ESP_IDF_VERSIONS: '["release-v5.5"]'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build ➜ ${{ matrix.idf_version }} · ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_version: [release-v5.5]
+        build_type: [Release, Debug]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz clang-format
+
+      - name: Format check
+        run: clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp
+
+      - name: Build documentation
+        run: doxygen Doxyfile
+
+      - name: ESP-IDF build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ matrix.idf_version }}
+          target: ${{ env.IDF_TARGET }}
+          path: .
+          command: |
+            idf.py create-project ${{ env.BUILD_PATH }}
+            cp example/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
+            rm -rf ${{ env.BUILD_PATH }}/main
+            cp -r example/main ${{ env.BUILD_PATH }}/main
+            idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
+            idf.py -C ${{ env.BUILD_PATH }} size-json > ${{ env.BUILD_PATH }}/build/size.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fw-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 14
+          path: |
+            ${{ env.BUILD_PATH }}/build/*.bin
+            ${{ env.BUILD_PATH }}/build/*.elf
+            ${{ env.BUILD_PATH }}/build/*.map
+            ${{ env.BUILD_PATH }}/build/size.*
+
+  static-analysis:
+    name: Static analyse (cppcheck + clang-tidy)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: Sydius/cppcheck-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: all
+          inconclusive: true
+          std: c99
+          include: main
+
+      - uses: ZedThree/clang-tidy-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .clang-tidy
+          style: file
+
+  codeql:
+    name: CodeQL static scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      security-events: write
+    steps:
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          tools: latest
+          queries: +security-extended
+      - uses: github/codeql-action/analyze@v3
+
+  workflow-lint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.6.25

--- a/.github/workflows/esp32c6.yml
+++ b/.github/workflows/esp32c6.yml
@@ -1,0 +1,38 @@
+name: ESP32C6 CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:release-v5.5
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build tools
+        run: |
+          apt-get update
+          apt-get install -y doxygen graphviz clang-format
+
+      - name: Format check
+        run: clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp
+
+      - name: Build documentation
+        run: doxygen Doxyfile
+
+      - name: Build Release
+        run: |
+          cd example
+          idf.py set-target esp32c6
+          idf.py -DCMAKE_BUILD_TYPE=Release build
+
+      - name: Build Debug
+        run: |
+          cd example
+          idf.py fullclean
+          idf.py set-target esp32c6
+          idf.py -DCMAKE_BUILD_TYPE=Debug build

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ Thumbs.db
 *.exe
 *.out
 *.app
+
+# Documentation
+docs/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
    ```bash
    doxygen Doxyfile
    ```
-   The HTML output can be found under `docs/html/index.html`.
+   The HTML output will be generated in `docs/html/index.html` (ignored from version control).
 
 ---
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.16)
+set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/..")
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(hf_ws2812_example)

--- a/example/main/CMakeLists.txt
+++ b/example/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS "."
+    REQUIRES hf-ws2812-rmt-driver
+)

--- a/example/main/main.cpp
+++ b/example/main/main.cpp
@@ -1,0 +1,6 @@
+#include "ws2812_cpp.hpp"
+
+extern "C" void app_main(void) {
+  WS2812Strip strip(GPIO_NUM_1, 0, 1, WS2812Strip::LedType::RGB);
+  (void)strip;
+}

--- a/include/led_strip_encoder.h
+++ b/include/led_strip_encoder.h
@@ -5,8 +5,8 @@
  */
 #pragma once
 
-#include <stdint.h>
 #include "driver/rmt_encoder.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,7 +16,7 @@ extern "C" {
  * @brief Type of led strip encoder configuration
  */
 typedef struct {
-    uint32_t resolution; /*!< Encoder resolution, in Hz */
+  uint32_t resolution; /*!< Encoder resolution, in Hz */
 } led_strip_encoder_config_t;
 
 /**
@@ -29,7 +29,8 @@ typedef struct {
  *      - ESP_ERR_NO_MEM out of memory when creating led strip encoder
  *      - ESP_OK if creating encoder successfully
  */
-esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder);
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config,
+                                    rmt_encoder_handle_t *ret_encoder);
 
 #ifdef __cplusplus
 }

--- a/include/rmt_wrapper.hpp
+++ b/include/rmt_wrapper.hpp
@@ -1,23 +1,26 @@
-// rmt_wrapper.hpp — High‑level C++ RAII wrapper for the ESP‑IDF v5.3 RMT driver on ESP32‑C6
-// Copyright (c) 2025 Nebiyu Tadesse
-// SPDX‑License‑Identifier: GPL‑3.0-or-later
+// rmt_wrapper.hpp — High‑level C++ RAII wrapper for the ESP‑IDF v5.3 RMT driver
+// on ESP32‑C6 Copyright (c) 2025 Nebiyu Tadesse SPDX‑License‑Identifier:
+// GPL‑3.0-or-later
 /**
  * @file rmt_wrapper.hpp
- * @brief A modern C++17 header‑only wrapper around the ESP‑IDF v5.3 “new” RMT driver.
+ * @brief A modern C++17 header‑only wrapper around the ESP‑IDF v5.3 “new” RMT
+ * driver.
  *
- * This façade hides the verbose C driver API behind a simple, type‑safe interface that
- * follows RAII, avoids memory leaks, and offers convenient helpers for typical tasks
- * such as WS2812/NeoPixel transmission or raw pulse capture/analysis.  It is designed
- * and tested for the ESP32‑C6 but should compile on any ESP‑IDF ≥ v5.0 target that
- * exposes the same driver layer.
+ * This façade hides the verbose C driver API behind a simple, type‑safe
+ * interface that follows RAII, avoids memory leaks, and offers convenient
+ * helpers for typical tasks such as WS2812/NeoPixel transmission or raw pulse
+ * capture/analysis.  It is designed and tested for the ESP32‑C6 but should
+ * compile on any ESP‑IDF ≥ v5.0 target that exposes the same driver layer.
  *
  * ## Features
- * * **Automatic channel allocation** when the caller does not care which of the four
- *   ESP32‑C6 RMT channels is used.
- * * **Strong error handling** via esp_err_t return codes and ESP_LOGE on failure.
+ * * **Automatic channel allocation** when the caller does not care which of the
+ * four ESP32‑C6 RMT channels is used.
+ * * **Strong error handling** via esp_err_t return codes and ESP_LOGE on
+ * failure.
  * * **Move‑only channel objects** to prevent accidental double‑free.
  * * **Built‑in bytes and WS2812 encoders** plus direct symbol streaming.
- * * **Idle‑timeout, glitch filter and queue‑based RX API** for robust waveform capture.
+ * * **Idle‑timeout, glitch filter and queue‑based RX API** for robust waveform
+ * capture.
  * * **Compile‑time checks** against wrong ESP‑IDF versions.
  *
  * ### Minimum snippet
@@ -27,8 +30,9 @@
  *
  * extern "C" void app_main(void)
  * {
- *     static constexpr gpio_num_t LED_PIN = GPIO_NUM_8;  // verified GPIO for ESP32‑C6
- *     hf::RmtTx tx(LED_PIN, 40'000'000);                 // 25 ns resolution
+ *     static constexpr gpio_num_t LED_PIN = GPIO_NUM_8;  // verified GPIO for
+ * ESP32‑C6 hf::RmtTx tx(LED_PIN, 40'000'000);                 // 25 ns
+ * resolution
  *
  *     uint8_t grb[3] = {0x00, 0xFF, 0x00};               // green pixel
  *     tx.transmit_ws2812(grb, sizeof(grb));
@@ -38,7 +42,7 @@
 #pragma once
 
 #if !defined(ESP_IDF_VERSION) || (ESP_IDF_VERSION_MAJOR < 5)
-#    error "This wrapper requires ESP‑IDF v5.0 or newer (uses the new RMT driver)."
+#error "This wrapper requires ESP‑IDF v5.0 or newer (uses the new RMT driver)."
 #endif
 
 #include <array>
@@ -51,28 +55,27 @@
 #include "esp_log.h"
 #include "esp_private/esp_clk.h"
 
+#include "driver/rmt_encoder.h"
 #include "driver/rmt_rx.h"
 #include "driver/rmt_tx.h"
-#include "driver/rmt_encoder.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
 namespace hf {
 
 namespace detail {
-[[nodiscard]] inline esp_err_t log_if_error(esp_err_t err, const char *tag, const char *msg)
-{
-    if (err != ESP_OK) {
-        ESP_LOGE(tag, "%s: %s", msg, esp_err_to_name(err));
-    }
-    return err;
+[[nodiscard]] inline esp_err_t log_if_error(esp_err_t err, const char *tag,
+                                            const char *msg) {
+  if (err != ESP_OK) {
+    ESP_LOGE(tag, "%s: %s", msg, esp_err_to_name(err));
+  }
+  return err;
 }
 
 //--- Tiny helper to search a free channel at run‑time (first‑fit) -------------
-[[nodiscard]] inline int allocate_rmt_channel()
-{
-    // Simply pick channel zero when automatic allocation is requested.
-    return 0;
+[[nodiscard]] inline int allocate_rmt_channel() {
+  // Simply pick channel zero when automatic allocation is requested.
+  return 0;
 }
 
 } // namespace detail
@@ -82,160 +85,165 @@ namespace detail {
 //=============================================================================
 class RmtTx {
 public:
-    /**
-     * @brief Create a transmit channel.
-     *
-     * @param gpio           Output GPIO number.
-     * @param resolution_hz  Clock resolution in Hz (max 40 MHz on ESP32‑C6).
-     * @param mem_symbols    Symbol memory per channel (in 32”bit words).
-     * @param with_dma       Enable DMA mode for huge transfers.
-     * @param queue_depth    Depth of internal transmit queue.
-     * @param clk_src        Clock source (default: RMT_CLK_SRC_DEFAULT).
-     * @param channel_id     [Optional] fixed channel (0‑3). Pass -1 for auto.
-     */
-    explicit RmtTx(gpio_num_t     gpio,
-                   uint32_t       resolution_hz = 10'000'000,
-                   size_t         mem_symbols   = 64,
-                   bool           with_dma      = false,
-                   uint32_t       queue_depth   = 4,
-                   rmt_clock_source_t clk_src = RMT_CLK_SRC_DEFAULT,
-                   int            channel_id    = -1)
-    {
-        constexpr char TAG[] = "RmtTx";
+  /**
+   * @brief Create a transmit channel.
+   *
+   * @param gpio           Output GPIO number.
+   * @param resolution_hz  Clock resolution in Hz (max 40 MHz on ESP32‑C6).
+   * @param mem_symbols    Symbol memory per channel (in 32”bit words).
+   * @param with_dma       Enable DMA mode for huge transfers.
+   * @param queue_depth    Depth of internal transmit queue.
+   * @param clk_src        Clock source (default: RMT_CLK_SRC_DEFAULT).
+   * @param channel_id     [Optional] fixed channel (0‑3). Pass -1 for auto.
+   */
+  explicit RmtTx(gpio_num_t gpio, uint32_t resolution_hz = 10'000'000,
+                 size_t mem_symbols = 64, bool with_dma = false,
+                 uint32_t queue_depth = 4,
+                 rmt_clock_source_t clk_src = RMT_CLK_SRC_DEFAULT,
+                 int channel_id = -1) {
+    constexpr char TAG[] = "RmtTx";
 
-        if (channel_id < 0) {
-            channel_id = detail::allocate_rmt_channel();
-            ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK : ESP_ERR_NOT_FOUND);
-        }
-
-        rmt_tx_channel_config_t cfg = {};
-        cfg.gpio_num = gpio;
-        cfg.clk_src = clk_src;
-        cfg.mem_block_symbols = mem_symbols;
-        cfg.resolution_hz = resolution_hz;
-        cfg.trans_queue_depth = queue_depth;
-        cfg.flags.invert_out = false;
-        cfg.flags.with_dma = with_dma;
-
-        ESP_ERROR_CHECK(detail::log_if_error(rmt_new_tx_channel(&cfg, &_handle), TAG,
-                                             "failed to create TX channel"));
-        ESP_ERROR_CHECK(detail::log_if_error(rmt_enable(_handle), TAG, "enable TX"));
-
-        // Prepare a generic copy encoder (raw symbol streaming)
-        rmt_copy_encoder_config_t copy_cfg = {};
-        ESP_ERROR_CHECK(rmt_new_copy_encoder(&copy_cfg, &_copy_encoder));
+    if (channel_id < 0) {
+      channel_id = detail::allocate_rmt_channel();
+      ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK
+                                                      : ESP_ERR_NOT_FOUND);
     }
 
-    RmtTx(const RmtTx &)            = delete;
-    RmtTx &operator=(const RmtTx &) = delete;
+    rmt_tx_channel_config_t cfg = {};
+    cfg.gpio_num = gpio;
+    cfg.clk_src = clk_src;
+    cfg.mem_block_symbols = mem_symbols;
+    cfg.resolution_hz = resolution_hz;
+    cfg.trans_queue_depth = queue_depth;
+    cfg.flags.invert_out = false;
+    cfg.flags.with_dma = with_dma;
 
-    RmtTx(RmtTx &&other) noexcept { *this = std::move(other); }
-    RmtTx &operator=(RmtTx &&other) noexcept
-    {
-        std::swap(_handle, other._handle);
-        std::swap(_copy_encoder, other._copy_encoder);
-        std::swap(_ws_encoder, other._ws_encoder);
-        return *this;
+    ESP_ERROR_CHECK(detail::log_if_error(rmt_new_tx_channel(&cfg, &_handle),
+                                         TAG, "failed to create TX channel"));
+    ESP_ERROR_CHECK(
+        detail::log_if_error(rmt_enable(_handle), TAG, "enable TX"));
+
+    // Prepare a generic copy encoder (raw symbol streaming)
+    rmt_copy_encoder_config_t copy_cfg = {};
+    ESP_ERROR_CHECK(rmt_new_copy_encoder(&copy_cfg, &_copy_encoder));
+  }
+
+  RmtTx(const RmtTx &) = delete;
+  RmtTx &operator=(const RmtTx &) = delete;
+
+  RmtTx(RmtTx &&other) noexcept { *this = std::move(other); }
+  RmtTx &operator=(RmtTx &&other) noexcept {
+    std::swap(_handle, other._handle);
+    std::swap(_copy_encoder, other._copy_encoder);
+    std::swap(_ws_encoder, other._ws_encoder);
+    return *this;
+  }
+
+  ~RmtTx() {
+    if (_ws_encoder)
+      rmt_del_encoder(_ws_encoder);
+    if (_copy_encoder)
+      rmt_del_encoder(_copy_encoder);
+    if (_handle)
+      rmt_disable(_handle), rmt_del_channel(_handle);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * @brief Transmit raw RMT symbols (blocking until done).
+   */
+  esp_err_t transmit(const rmt_symbol_word_t *symbols, size_t count,
+                     TickType_t timeout = portMAX_DELAY) const {
+    rmt_transmit_config_t tx_cfg = {};
+    tx_cfg.loop_count = 0;
+    esp_err_t err = rmt_transmit(_handle, _copy_encoder, symbols,
+                                 count * sizeof(rmt_symbol_word_t), &tx_cfg);
+    if (err != ESP_OK)
+      return err;
+    return rmt_tx_wait_all_done(_handle, timeout);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * @brief Transmit an arbitrary byte stream with custom bit timing.
+   *
+   * @param bit0  Symbol encoding logic‑0 (LSB first by default).
+   * @param bit1  Symbol encoding logic‑1.
+   */
+  esp_err_t transmit_bytes(const uint8_t *data, size_t length,
+                           const rmt_symbol_word_t &bit0,
+                           const rmt_symbol_word_t &bit1,
+                           TickType_t timeout = portMAX_DELAY) {
+    // Create a throw‑away bytes encoder (kept only for this call)
+    rmt_bytes_encoder_config_t be_cfg = {};
+    be_cfg.bit0 = bit0;
+    be_cfg.bit1 = bit1;
+    be_cfg.flags.msb_first = true;
+    rmt_encoder_handle_t bytes_enc = nullptr;
+    ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&be_cfg, &bytes_enc), "RmtTx",
+                        "new bytes enc");
+
+    rmt_transmit_config_t tx_cfg = {};
+    tx_cfg.loop_count = 0;
+    esp_err_t err = rmt_transmit(_handle, bytes_enc, data, length, &tx_cfg);
+    if (err == ESP_OK)
+      err = rmt_tx_wait_all_done(_handle, timeout);
+    rmt_del_encoder(bytes_enc);
+    return err;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * @brief Helper dedicated to WS2812/NeoPixel @ 800 kHz.
+   * Uses 10 MHz or faster resolution to achieve accurate timings.
+   */
+  esp_err_t transmit_ws2812(const uint8_t *grb, size_t length,
+                            TickType_t timeout = portMAX_DELAY) {
+    if (!_ws_encoder) {
+      rmt_bytes_encoder_config_t ws_cfg = {};
+      ws_cfg.bit0 = make_ws2812_bit0();
+      ws_cfg.bit1 = make_ws2812_bit1();
+      ws_cfg.flags.msb_first = true;
+      ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&ws_cfg, &_ws_encoder), "RmtTx",
+                          "new ws2812 enc");
     }
+    rmt_transmit_config_t tx_cfg = {};
+    tx_cfg.loop_count = 0;
+    esp_err_t err = rmt_transmit(_handle, _ws_encoder, grb, length, &tx_cfg);
+    if (err == ESP_OK)
+      err = rmt_tx_wait_all_done(_handle, timeout);
+    return err;
+  }
 
-    ~RmtTx()
-    {
-        if (_ws_encoder) rmt_del_encoder(_ws_encoder);
-        if (_copy_encoder) rmt_del_encoder(_copy_encoder);
-        if (_handle) rmt_disable(_handle), rmt_del_channel(_handle);
-    }
-
-    //-------------------------------------------------------------------------
-    /**
-     * @brief Transmit raw RMT symbols (blocking until done).
-     */
-    esp_err_t transmit(const rmt_symbol_word_t *symbols, size_t count,
-                       TickType_t timeout = portMAX_DELAY) const
-    {
-        rmt_transmit_config_t tx_cfg = {};
-        tx_cfg.loop_count = 0;
-        esp_err_t err = rmt_transmit(_handle, _copy_encoder, symbols, count * sizeof(rmt_symbol_word_t),
-                                     &tx_cfg);
-        if (err != ESP_OK) return err;
-        return rmt_tx_wait_all_done(_handle, timeout);
-    }
-
-    //-------------------------------------------------------------------------
-    /**
-     * @brief Transmit an arbitrary byte stream with custom bit timing.
-     *
-     * @param bit0  Symbol encoding logic‑0 (LSB first by default).
-     * @param bit1  Symbol encoding logic‑1.
-     */
-    esp_err_t transmit_bytes(const uint8_t             *data,
-                             size_t                     length,
-                             const rmt_symbol_word_t   &bit0,
-                             const rmt_symbol_word_t   &bit1,
-                             TickType_t                 timeout = portMAX_DELAY)
-    {
-        // Create a throw‑away bytes encoder (kept only for this call)
-        rmt_bytes_encoder_config_t be_cfg = {};
-        be_cfg.bit0 = bit0;
-        be_cfg.bit1 = bit1;
-        be_cfg.flags.msb_first = true;
-        rmt_encoder_handle_t bytes_enc = nullptr;
-        ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&be_cfg, &bytes_enc), "RmtTx", "new bytes enc");
-
-        rmt_transmit_config_t tx_cfg = {};
-        tx_cfg.loop_count = 0;
-        esp_err_t err = rmt_transmit(_handle, bytes_enc, data, length, &tx_cfg);
-        if (err == ESP_OK) err = rmt_tx_wait_all_done(_handle, timeout);
-        rmt_del_encoder(bytes_enc);
-        return err;
-    }
-
-    //-------------------------------------------------------------------------
-    /**
-     * @brief Helper dedicated to WS2812/NeoPixel @ 800 kHz.
-     * Uses 10 MHz or faster resolution to achieve accurate timings.
-     */
-    esp_err_t transmit_ws2812(const uint8_t *grb, size_t length,
-                              TickType_t timeout = portMAX_DELAY)
-    {
-        if (!_ws_encoder) {
-            rmt_bytes_encoder_config_t ws_cfg = {};
-            ws_cfg.bit0 = make_ws2812_bit0();
-            ws_cfg.bit1 = make_ws2812_bit1();
-            ws_cfg.flags.msb_first = true;
-            ESP_RETURN_ON_ERROR(rmt_new_bytes_encoder(&ws_cfg, &_ws_encoder), "RmtTx",
-                                "new ws2812 enc");
-        }
-        rmt_transmit_config_t tx_cfg = {};
-        tx_cfg.loop_count = 0;
-        esp_err_t err = rmt_transmit(_handle, _ws_encoder, grb, length, &tx_cfg);
-        if (err == ESP_OK) err = rmt_tx_wait_all_done(_handle, timeout);
-        return err;
-    }
-
-    rmt_channel_handle_t handle() const { return _handle; }
+  rmt_channel_handle_t handle() const { return _handle; }
 
 private:
-    static constexpr rmt_symbol_word_t make_ws2812_bit0(uint32_t resolution_hz = 10'000'000)
-    {
-        // T0H=0.4 μs, T0L≈0.85 μs
-        uint32_t ticks_h = (400'000'000ULL / resolution_hz + 9) / 10;   // round‑nearest
-        uint32_t ticks_l = (850'000'000ULL / resolution_hz + 9) / 10;
-        return {.duration0 = (uint16_t)ticks_h, .level0 = 1,
-                .duration1 = (uint16_t)ticks_l, .level1 = 0};
-    }
+  static constexpr rmt_symbol_word_t
+  make_ws2812_bit0(uint32_t resolution_hz = 10'000'000) {
+    // T0H=0.4 μs, T0L≈0.85 μs
+    uint32_t ticks_h =
+        (400'000'000ULL / resolution_hz + 9) / 10; // round‑nearest
+    uint32_t ticks_l = (850'000'000ULL / resolution_hz + 9) / 10;
+    return {.duration0 = (uint16_t)ticks_h,
+            .level0 = 1,
+            .duration1 = (uint16_t)ticks_l,
+            .level1 = 0};
+  }
 
-    static constexpr rmt_symbol_word_t make_ws2812_bit1(uint32_t resolution_hz = 10'000'000)
-    {
-        // T1H=0.8 μs, T1L≈0.45 μs
-        uint32_t ticks_h = (800'000'000ULL / resolution_hz + 9) / 10;
-        uint32_t ticks_l = (450'000'000ULL / resolution_hz + 9) / 10;
-        return {.duration0 = (uint16_t)ticks_h, .level0 = 1,
-                .duration1 = (uint16_t)ticks_l, .level1 = 0};
-    }
+  static constexpr rmt_symbol_word_t
+  make_ws2812_bit1(uint32_t resolution_hz = 10'000'000) {
+    // T1H=0.8 μs, T1L≈0.45 μs
+    uint32_t ticks_h = (800'000'000ULL / resolution_hz + 9) / 10;
+    uint32_t ticks_l = (450'000'000ULL / resolution_hz + 9) / 10;
+    return {.duration0 = (uint16_t)ticks_h,
+            .level0 = 1,
+            .duration1 = (uint16_t)ticks_l,
+            .level1 = 0};
+  }
 
-    rmt_channel_handle_t _handle      = nullptr;
-    rmt_encoder_handle_t _copy_encoder = nullptr;
-    rmt_encoder_handle_t _ws_encoder   = nullptr;
+  rmt_channel_handle_t _handle = nullptr;
+  rmt_encoder_handle_t _copy_encoder = nullptr;
+  rmt_encoder_handle_t _ws_encoder = nullptr;
 };
 
 //=============================================================================
@@ -243,96 +251,95 @@ private:
 //=============================================================================
 class RmtRx {
 public:
-    explicit RmtRx(gpio_num_t     gpio,
-                   uint32_t       resolution_hz     = 10'000'000,
-                   size_t         mem_symbols       = 64,
-                   uint32_t       idle_threshold_us = 1000,
-                   uint32_t       filter_ns         = 200,
-                   rmt_clock_source_t clk_src        = RMT_CLK_SRC_DEFAULT,
-                   int            channel_id        = -1)
-    {
-        constexpr char TAG[] = "RmtRx";
+  explicit RmtRx(gpio_num_t gpio, uint32_t resolution_hz = 10'000'000,
+                 size_t mem_symbols = 64, uint32_t idle_threshold_us = 1000,
+                 uint32_t filter_ns = 200,
+                 rmt_clock_source_t clk_src = RMT_CLK_SRC_DEFAULT,
+                 int channel_id = -1) {
+    constexpr char TAG[] = "RmtRx";
 
-        if (channel_id < 0) {
-            channel_id = detail::allocate_rmt_channel();
-            ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK : ESP_ERR_NOT_FOUND);
-        }
-
-        rmt_rx_channel_config_t cfg = {};
-        cfg.gpio_num = gpio;
-        cfg.clk_src = clk_src;
-        cfg.mem_block_symbols = mem_symbols;
-        cfg.resolution_hz = resolution_hz;
-        cfg.flags.invert_in = false;
-        ESP_ERROR_CHECK(detail::log_if_error(rmt_new_rx_channel(&cfg, &_handle), TAG,
-                                             "create RX"));
-
-        rmt_rx_event_callbacks_t cbs = {};
-        cbs.on_recv_done = &RmtRx::rx_done_cb_static;
-        ESP_ERROR_CHECK(rmt_rx_register_event_callbacks(_handle, &cbs, this));
-        ESP_ERROR_CHECK(rmt_enable(_handle));
-
-        // Create queue for ISR -> task communication
-        _queue = xQueueCreate(4, sizeof(size_t));
-
-        // Configure RX receive behavior (can be changed later)
-        _rcv_cfg.signal_range_max_ns = idle_threshold_us * 1000ULL;
-        _rcv_cfg.signal_range_min_ns = filter_ns;
+    if (channel_id < 0) {
+      channel_id = detail::allocate_rmt_channel();
+      ESP_ERROR_CHECK_WITHOUT_ABORT((channel_id >= 0) ? ESP_OK
+                                                      : ESP_ERR_NOT_FOUND);
     }
 
-    RmtRx(const RmtRx &)            = delete;
-    RmtRx &operator=(const RmtRx &) = delete;
-    RmtRx(RmtRx &&o) noexcept { *this = std::move(o); }
-    RmtRx &operator=(RmtRx &&o) noexcept
-    {
-        std::swap(_handle, o._handle);
-        std::swap(_queue, o._queue);
-        std::swap(_rcv_cfg, o._rcv_cfg);
-        return *this;
+    rmt_rx_channel_config_t cfg = {};
+    cfg.gpio_num = gpio;
+    cfg.clk_src = clk_src;
+    cfg.mem_block_symbols = mem_symbols;
+    cfg.resolution_hz = resolution_hz;
+    cfg.flags.invert_in = false;
+    ESP_ERROR_CHECK(detail::log_if_error(rmt_new_rx_channel(&cfg, &_handle),
+                                         TAG, "create RX"));
+
+    rmt_rx_event_callbacks_t cbs = {};
+    cbs.on_recv_done = &RmtRx::rx_done_cb_static;
+    ESP_ERROR_CHECK(rmt_rx_register_event_callbacks(_handle, &cbs, this));
+    ESP_ERROR_CHECK(rmt_enable(_handle));
+
+    // Create queue for ISR -> task communication
+    _queue = xQueueCreate(4, sizeof(size_t));
+
+    // Configure RX receive behavior (can be changed later)
+    _rcv_cfg.signal_range_max_ns = idle_threshold_us * 1000ULL;
+    _rcv_cfg.signal_range_min_ns = filter_ns;
+  }
+
+  RmtRx(const RmtRx &) = delete;
+  RmtRx &operator=(const RmtRx &) = delete;
+  RmtRx(RmtRx &&o) noexcept { *this = std::move(o); }
+  RmtRx &operator=(RmtRx &&o) noexcept {
+    std::swap(_handle, o._handle);
+    std::swap(_queue, o._queue);
+    std::swap(_rcv_cfg, o._rcv_cfg);
+    return *this;
+  }
+
+  ~RmtRx() {
+    if (_handle)
+      rmt_disable(_handle), rmt_del_channel(_handle);
+    if (_queue)
+      vQueueDelete(_queue);
+  }
+
+  /**
+   * @brief Start a single receive transaction and block until it completes.
+   *
+   * The caller must provide a buffer sized to hold `buffer_symbols` symbols.
+   */
+  esp_err_t receive(rmt_symbol_word_t *buffer, size_t buffer_symbols,
+                    size_t *out_symbols, TickType_t timeout = portMAX_DELAY) {
+    if (!buffer || !out_symbols)
+      return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err = rmt_receive(
+        _handle, buffer, buffer_symbols * sizeof(rmt_symbol_word_t), &_rcv_cfg);
+    if (err != ESP_OK)
+      return err;
+
+    // Wait until ISR posts the symbol count
+    if (xQueueReceive(_queue, out_symbols, timeout) != pdPASS) {
+      return ESP_ERR_TIMEOUT;
     }
+    return ESP_OK;
+  }
 
-    ~RmtRx()
-    {
-        if (_handle) rmt_disable(_handle), rmt_del_channel(_handle);
-        if (_queue) vQueueDelete(_queue);
-    }
-
-    /**
-     * @brief Start a single receive transaction and block until it completes.
-     *
-     * The caller must provide a buffer sized to hold `buffer_symbols` symbols.
-     */
-    esp_err_t receive(rmt_symbol_word_t *buffer, size_t buffer_symbols,
-                      size_t *out_symbols, TickType_t timeout = portMAX_DELAY)
-    {
-        if (!buffer || !out_symbols) return ESP_ERR_INVALID_ARG;
-
-        esp_err_t err = rmt_receive(_handle, buffer, buffer_symbols * sizeof(rmt_symbol_word_t),
-                                    &_rcv_cfg);
-        if (err != ESP_OK) return err;
-
-        // Wait until ISR posts the symbol count
-        if (xQueueReceive(_queue, out_symbols, timeout) != pdPASS) {
-            return ESP_ERR_TIMEOUT;
-        }
-        return ESP_OK;
-    }
-
-    rmt_channel_handle_t handle() const { return _handle; }
+  rmt_channel_handle_t handle() const { return _handle; }
 
 private:
-    static bool rx_done_cb_static(rmt_channel_handle_t /*chan*/,
-                                  const rmt_rx_done_event_data_t *edata, void *user_ctx)
-    {
-        auto *self = static_cast<RmtRx *>(user_ctx);
-        BaseType_t HPW = pdFALSE;
-        xQueueSendFromISR(self->_queue, &edata->num_symbols, &HPW);
-        return HPW == pdTRUE; // context switch request
-    }
+  static bool rx_done_cb_static(rmt_channel_handle_t /*chan*/,
+                                const rmt_rx_done_event_data_t *edata,
+                                void *user_ctx) {
+    auto *self = static_cast<RmtRx *>(user_ctx);
+    BaseType_t HPW = pdFALSE;
+    xQueueSendFromISR(self->_queue, &edata->num_symbols, &HPW);
+    return HPW == pdTRUE; // context switch request
+  }
 
-    rmt_channel_handle_t   _handle  = nullptr;
-    QueueHandle_t          _queue   = nullptr;
-    rmt_receive_config_t   _rcv_cfg = {};
+  rmt_channel_handle_t _handle = nullptr;
+  QueueHandle_t _queue = nullptr;
+  rmt_receive_config_t _rcv_cfg = {};
 };
 
 } // namespace hf

--- a/include/ws2812_control.h
+++ b/include/ws2812_control.h
@@ -10,13 +10,13 @@
  * functions declared here form the public interface for the driver.
  */
 
-#include <stdint.h>
-#include "sdkconfig.h"
-#include "esp_err.h"
 #include "driver/gpio.h"
 #include "driver/rmt_tx.h"
 #include "driver/rmt_types.h"
+#include "esp_err.h"
 #include "led_strip_encoder.h"
+#include "sdkconfig.h"
+#include <stdint.h>
 
 /**
  * @name Driver constants
@@ -60,8 +60,8 @@ extern "C" {
  * white channel value.
  */
 struct led_state {
-    /** Array of packed color values for each LED. */
-    uint32_t leds[NUM_LEDS];
+  /** Array of packed color values for each LED. */
+  uint32_t leds[NUM_LEDS];
 };
 
 /**

--- a/include/ws2812_cpp.hpp
+++ b/include/ws2812_cpp.hpp
@@ -11,10 +11,10 @@
 #ifndef WS2812_CPP_HPP
 #define WS2812_CPP_HPP
 
-#include "ws2812_control.h"
 #include "rmt_wrapper.hpp"
-#include <vector>
+#include "ws2812_control.h"
 #include <cstdint>
+#include <vector>
 
 #ifdef __cplusplus
 
@@ -30,86 +30,84 @@ enum class LedType { RGB, RGBW };
  */
 class WS2812Strip {
 public:
-    /**
-     * @brief Construct a strip object.
-     *
-     * @param gpio    Output pin connected to the LEDs.
-     * @param channel RMT channel for signal generation.
-     */
-    explicit WS2812Strip(gpio_num_t gpio = (gpio_num_t)CONFIG_WS2812_LED_RMT_TX_GPIO,
-                         int channel = CONFIG_WS2812_LED_RMT_TX_CHANNEL,
-                         uint32_t numLeds = NUM_LEDS,
+  /**
+   * @brief Construct a strip object.
+   *
+   * @param gpio    Output pin connected to the LEDs.
+   * @param channel RMT channel for signal generation.
+   */
+  explicit WS2812Strip(gpio_num_t gpio = (gpio_num_t)
+                           CONFIG_WS2812_LED_RMT_TX_GPIO,
+                       int channel = CONFIG_WS2812_LED_RMT_TX_CHANNEL,
+                       uint32_t numLeds = NUM_LEDS,
 #if CONFIG_WS2812_LED_TYPE_RGBW
-                         LedType type = LedType::RGBW,
+                       LedType type = LedType::RGBW,
 #else
-                         LedType type = LedType::RGB,
+                       LedType type = LedType::RGB,
 #endif
-                         uint16_t t0h = WS2812_T0H,
-                         uint16_t t1h = WS2812_T1H,
-                         uint16_t t0l = WS2812_T0L,
-                         uint16_t t1l = WS2812_T1L,
-                         uint8_t brightness = WS2812_DEFAULT_BRIGHTNESS);
+                       uint16_t t0h = WS2812_T0H, uint16_t t1h = WS2812_T1H,
+                       uint16_t t0l = WS2812_T0L, uint16_t t1l = WS2812_T1L,
+                       uint8_t brightness = WS2812_DEFAULT_BRIGHTNESS);
 
-    /**
-     * @brief Initialise the underlying driver.
-     *
-     * @return ESP_OK on success.
-     */
-    esp_err_t begin();
+  /**
+   * @brief Initialise the underlying driver.
+   *
+   * @return ESP_OK on success.
+   */
+  esp_err_t begin();
 
-    /**
-     * @brief Set the colour of a single LED.
-     *
-     * @param index Index of the LED starting from 0.
-     * @param rgbw Packed 24/32-bit colour value.
-     */
-    void setPixel(uint32_t index, uint32_t rgbw);
+  /**
+   * @brief Set the colour of a single LED.
+   *
+   * @param index Index of the LED starting from 0.
+   * @param rgbw Packed 24/32-bit colour value.
+   */
+  void setPixel(uint32_t index, uint32_t rgbw);
 
-    /** Get the number of LEDs managed by this strip. */
-    uint32_t length() const;
+  /** Get the number of LEDs managed by this strip. */
+  uint32_t length() const;
 
-    /**
-     * @brief Send the currently stored colours to the LED strip.
-     */
-    esp_err_t show();
+  /**
+   * @brief Send the currently stored colours to the LED strip.
+   */
+  esp_err_t show();
 
-    /**
-     * @brief Set global brightness for the strip.
-     *
-     * @param value Brightness 0-255.
-     */
-    void setBrightness(uint8_t value);
+  /**
+   * @brief Set global brightness for the strip.
+   *
+   * @param value Brightness 0-255.
+   */
+  void setBrightness(uint8_t value);
 
-    /**
-     * @brief Update the bit timing parameters.
-     *
-     * Allows adjustment of the WS2812 protocol timings after construction.
-     */
-    void setTimings(uint16_t t0h, uint16_t t1h, uint16_t t0l, uint16_t t1l);
+  /**
+   * @brief Update the bit timing parameters.
+   *
+   * Allows adjustment of the WS2812 protocol timings after construction.
+   */
+  void setTimings(uint16_t t0h, uint16_t t1h, uint16_t t0l, uint16_t t1l);
 
-    /**
-     * @brief Generate a colour from a 0-255 position on a colour wheel.
-     *
-     * @param pos Position on the colour wheel.
-     * @return Packed RGB colour.
-     */
-    static uint32_t colorWheel(uint8_t pos);
+  /**
+   * @brief Generate a colour from a 0-255 position on a colour wheel.
+   *
+   * @param pos Position on the colour wheel.
+   * @return Packed RGB colour.
+   */
+  static uint32_t colorWheel(uint8_t pos);
 
 private:
-    std::vector<uint32_t> m_pixels;
-    std::vector<rmt_symbol_word_t> m_buffer;
-    hf::RmtTx m_rmt;
-    gpio_num_t m_gpio;
-    int m_channel;
-    LedType m_type;
-    uint16_t m_t0h;
-    uint16_t m_t1h;
-    uint16_t m_t0l;
-    uint16_t m_t1l;
-    uint8_t m_brightness;
-    uint32_t m_numLeds;
+  std::vector<uint32_t> m_pixels;
+  std::vector<rmt_symbol_word_t> m_buffer;
+  hf::RmtTx m_rmt;
+  gpio_num_t m_gpio;
+  int m_channel;
+  LedType m_type;
+  uint16_t m_t0h;
+  uint16_t m_t1h;
+  uint16_t m_t0l;
+  uint16_t m_t1l;
+  uint8_t m_brightness;
+  uint32_t m_numLeds;
 };
-
 
 #endif // __cplusplus
 

--- a/include/ws2812_effects.hpp
+++ b/include/ws2812_effects.hpp
@@ -13,49 +13,40 @@
  */
 class WS2812Animator {
 public:
-    enum class Effect {
-        Off,
-        SolidColor,
-        Rainbow,
-        Chase,
-        Blink,
-        Breath,
-        Larson
-    };
+  enum class Effect { Off, SolidColor, Rainbow, Chase, Blink, Breath, Larson };
 
-    explicit WS2812Animator(WS2812Strip &strip, uint32_t virtualLength = 0);
+  explicit WS2812Animator(WS2812Strip &strip, uint32_t virtualLength = 0);
 
-    /**
-     * @brief Select the active effect.
-     *
-     * @param effect Desired pattern.
-     * @param color  Base colour used by some effects.
-     */
-    void setEffect(Effect effect, uint32_t color = 0xFFFFFF);
+  /**
+   * @brief Select the active effect.
+   *
+   * @param effect Desired pattern.
+   * @param color  Base colour used by some effects.
+   */
+  void setEffect(Effect effect, uint32_t color = 0xFFFFFF);
 
-    /** Adjust the virtual length used for effects. */
-    void setVirtualLength(uint32_t length);
+  /** Adjust the virtual length used for effects. */
+  void setVirtualLength(uint32_t length);
 
-    /** Set the current step (used for external synchronization). */
-    void setStep(uint16_t step);
-    uint16_t step() const;
+  /** Set the current step (used for external synchronization). */
+  void setStep(uint16_t step);
+  uint16_t step() const;
 
-    /**
-     * @brief Advance the animation by one step.
-     */
-    void tick();
+  /**
+   * @brief Advance the animation by one step.
+   */
+  void tick();
 
 private:
-    WS2812Strip &m_strip;
-    bool m_initialized = false;
-    uint32_t m_virtualLength = 0;
-    Effect m_effect = Effect::Off;
-    uint32_t m_color = 0xFFFFFF;
-    uint16_t m_step = 0;
-    int m_dir = 1;
-    uint8_t m_brightness = 0;
+  WS2812Strip &m_strip;
+  bool m_initialized = false;
+  uint32_t m_virtualLength = 0;
+  Effect m_effect = Effect::Off;
+  uint32_t m_color = 0xFFFFFF;
+  uint16_t m_step = 0;
+  int m_dir = 1;
+  uint8_t m_brightness = 0;
 };
-
 
 #endif // __cplusplus
 

--- a/include/ws2812_multi_animator.hpp
+++ b/include/ws2812_multi_animator.hpp
@@ -11,42 +11,43 @@
  */
 class WS2812MultiAnimator {
 public:
-    /**
-     * @brief Construct from a list of strips.
-     *
-     * @param strips   Pointers to WS2812Strip objects.
-     * @param unified  If true all strips share the longest length.
-     * @param sync     If true keep animation steps in sync.
-     */
-    explicit WS2812MultiAnimator(const std::vector<WS2812Strip*>& strips,
-                                 bool unified = true, bool sync = true);
+  /**
+   * @brief Construct from a list of strips.
+   *
+   * @param strips   Pointers to WS2812Strip objects.
+   * @param unified  If true all strips share the longest length.
+   * @param sync     If true keep animation steps in sync.
+   */
+  explicit WS2812MultiAnimator(const std::vector<WS2812Strip *> &strips,
+                               bool unified = true, bool sync = true);
 
-    /**
-     * @brief Apply an effect to all managed strips.
-     */
-    void setEffect(WS2812Animator::Effect eff, uint32_t color = 0xFFFFFF);
+  /**
+   * @brief Apply an effect to all managed strips.
+   */
+  void setEffect(WS2812Animator::Effect eff, uint32_t color = 0xFFFFFF);
 
-    /**
-     * @brief Apply an effect to a single strip.
-     *
-     * @param idx   Index of the strip.
-     * @param eff   Desired animation effect.
-     * @param color Base colour for the effect.
-     */
-    void setEffect(size_t idx, WS2812Animator::Effect eff, uint32_t color = 0xFFFFFF);
+  /**
+   * @brief Apply an effect to a single strip.
+   *
+   * @param idx   Index of the strip.
+   * @param eff   Desired animation effect.
+   * @param color Base colour for the effect.
+   */
+  void setEffect(size_t idx, WS2812Animator::Effect eff,
+                 uint32_t color = 0xFFFFFF);
 
-    /**
-     * @brief Advance all animations by one step.
-     */
-    void tick();
+  /**
+   * @brief Advance all animations by one step.
+   */
+  void tick();
 
 private:
-    /** Animators for each strip. */
-    std::vector<WS2812Animator> m_animators;
-    /** Synchronise step counters across strips. */
-    bool m_sync = true;
-    /** Current animation step used for synchronisation. */
-    uint16_t m_step = 0;
+  /** Animators for each strip. */
+  std::vector<WS2812Animator> m_animators;
+  /** Synchronise step counters across strips. */
+  bool m_sync = true;
+  /** Current animation step used for synchronisation. */
+  uint16_t m_step = 0;
 };
 #endif // __cplusplus
 

--- a/src/led_strip_encoder.c
+++ b/src/led_strip_encoder.c
@@ -4,121 +4,138 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "esp_check.h"
 #include "led_strip_encoder.h"
+#include "esp_check.h"
 
 static const char *TAG = "led_encoder";
 
 typedef struct {
-    rmt_encoder_t base;
-    rmt_encoder_t *bytes_encoder;
-    rmt_encoder_t *copy_encoder;
-    int state;
-    rmt_symbol_word_t reset_code;
+  rmt_encoder_t base;
+  rmt_encoder_t *bytes_encoder;
+  rmt_encoder_t *copy_encoder;
+  int state;
+  rmt_symbol_word_t reset_code;
 } rmt_led_strip_encoder_t;
 
-static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
-{
-    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
-    rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
-    rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
-    rmt_encode_state_t session_state = RMT_ENCODING_RESET;
-    rmt_encode_state_t state = RMT_ENCODING_RESET;
-    size_t encoded_symbols = 0;
-    switch (led_encoder->state) {
-    case 0: // send RGB data
-        encoded_symbols += bytes_encoder->encode(bytes_encoder, channel, primary_data, data_size, &session_state);
-        if (session_state & RMT_ENCODING_COMPLETE) {
-            led_encoder->state = 1; // switch to next state when current encoding session finished
-        }
-        if (session_state & RMT_ENCODING_MEM_FULL) {
-            state |= RMT_ENCODING_MEM_FULL;
-            goto out; // yield if there's no free space for encoding artifacts
-        }
-    // fall-through
-    case 1: // send reset code
-        encoded_symbols += copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code,
-                                                sizeof(led_encoder->reset_code), &session_state);
-        if (session_state & RMT_ENCODING_COMPLETE) {
-            led_encoder->state = RMT_ENCODING_RESET; // back to the initial encoding session
-            state |= RMT_ENCODING_COMPLETE;
-        }
-        if (session_state & RMT_ENCODING_MEM_FULL) {
-            state |= RMT_ENCODING_MEM_FULL;
-            goto out; // yield if there's no free space for encoding artifacts
-        }
+static size_t rmt_encode_led_strip(rmt_encoder_t *encoder,
+                                   rmt_channel_handle_t channel,
+                                   const void *primary_data, size_t data_size,
+                                   rmt_encode_state_t *ret_state) {
+  rmt_led_strip_encoder_t *led_encoder =
+      __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
+  rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
+  rmt_encode_state_t session_state = RMT_ENCODING_RESET;
+  rmt_encode_state_t state = RMT_ENCODING_RESET;
+  size_t encoded_symbols = 0;
+  switch (led_encoder->state) {
+  case 0: // send RGB data
+    encoded_symbols += bytes_encoder->encode(
+        bytes_encoder, channel, primary_data, data_size, &session_state);
+    if (session_state & RMT_ENCODING_COMPLETE) {
+      led_encoder->state =
+          1; // switch to next state when current encoding session finished
     }
+    if (session_state & RMT_ENCODING_MEM_FULL) {
+      state |= RMT_ENCODING_MEM_FULL;
+      goto out; // yield if there's no free space for encoding artifacts
+    }
+  // fall-through
+  case 1: // send reset code
+    encoded_symbols +=
+        copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code,
+                             sizeof(led_encoder->reset_code), &session_state);
+    if (session_state & RMT_ENCODING_COMPLETE) {
+      led_encoder->state =
+          RMT_ENCODING_RESET; // back to the initial encoding session
+      state |= RMT_ENCODING_COMPLETE;
+    }
+    if (session_state & RMT_ENCODING_MEM_FULL) {
+      state |= RMT_ENCODING_MEM_FULL;
+      goto out; // yield if there's no free space for encoding artifacts
+    }
+  }
 out:
-    *ret_state = state;
-    return encoded_symbols;
+  *ret_state = state;
+  return encoded_symbols;
 }
 
-static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder)
-{
-    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
-    rmt_del_encoder(led_encoder->bytes_encoder);
-    rmt_del_encoder(led_encoder->copy_encoder);
-    free(led_encoder);
-    return ESP_OK;
+static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder) {
+  rmt_led_strip_encoder_t *led_encoder =
+      __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_del_encoder(led_encoder->bytes_encoder);
+  rmt_del_encoder(led_encoder->copy_encoder);
+  free(led_encoder);
+  return ESP_OK;
 }
 
-static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
-{
-    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
-    rmt_encoder_reset(led_encoder->bytes_encoder);
-    rmt_encoder_reset(led_encoder->copy_encoder);
-    led_encoder->state = RMT_ENCODING_RESET;
-    return ESP_OK;
+static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder) {
+  rmt_led_strip_encoder_t *led_encoder =
+      __containerof(encoder, rmt_led_strip_encoder_t, base);
+  rmt_encoder_reset(led_encoder->bytes_encoder);
+  rmt_encoder_reset(led_encoder->copy_encoder);
+  led_encoder->state = RMT_ENCODING_RESET;
+  return ESP_OK;
 }
 
-esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder)
-{
-    esp_err_t ret = ESP_OK;
-    rmt_led_strip_encoder_t *led_encoder = NULL;
-    ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
-    led_encoder = rmt_alloc_encoder_mem(sizeof(rmt_led_strip_encoder_t));
-    ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG, "no mem for led strip encoder");
-    led_encoder->base.encode = rmt_encode_led_strip;
-    led_encoder->base.del = rmt_del_led_strip_encoder;
-    led_encoder->base.reset = rmt_led_strip_encoder_reset;
-    // different led strip might have its own timing requirements, following parameter is for WS2812
-    rmt_bytes_encoder_config_t bytes_encoder_config = {
-        .bit0 = {
-            .level0 = 1,
-            .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
-            .level1 = 0,
-            .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
-        },
-        .bit1 = {
-            .level0 = 1,
-            .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
-            .level1 = 0,
-            .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
-        },
-        .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
-    };
-    ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
-    rmt_copy_encoder_config_t copy_encoder_config = {};
-    ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config,
+                                    rmt_encoder_handle_t *ret_encoder) {
+  esp_err_t ret = ESP_OK;
+  rmt_led_strip_encoder_t *led_encoder = NULL;
+  ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG,
+                    "invalid argument");
+  led_encoder = rmt_alloc_encoder_mem(sizeof(rmt_led_strip_encoder_t));
+  ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG,
+                    "no mem for led strip encoder");
+  led_encoder->base.encode = rmt_encode_led_strip;
+  led_encoder->base.del = rmt_del_led_strip_encoder;
+  led_encoder->base.reset = rmt_led_strip_encoder_reset;
+  // different led strip might have its own timing requirements, following
+  // parameter is for WS2812
+  rmt_bytes_encoder_config_t bytes_encoder_config = {
+      .bit0 =
+          {
+              .level0 = 1,
+              .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+              .level1 = 0,
+              .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+          },
+      .bit1 =
+          {
+              .level0 = 1,
+              .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
+              .level1 = 0,
+              .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
+          },
+      .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
+  };
+  ESP_GOTO_ON_ERROR(
+      rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder),
+      err, TAG, "create bytes encoder failed");
+  rmt_copy_encoder_config_t copy_encoder_config = {};
+  ESP_GOTO_ON_ERROR(
+      rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder),
+      err, TAG, "create copy encoder failed");
 
-    uint32_t reset_ticks = config->resolution / 1000000 * 50 / 2; // reset code duration defaults to 50us
-    led_encoder->reset_code = (rmt_symbol_word_t) {
-        .level0 = 0,
-        .duration0 = reset_ticks,
-        .level1 = 0,
-        .duration1 = reset_ticks,
-    };
-    *ret_encoder = &led_encoder->base;
-    return ESP_OK;
+  uint32_t reset_ticks = config->resolution / 1000000 * 50 /
+                         2; // reset code duration defaults to 50us
+  led_encoder->reset_code = (rmt_symbol_word_t){
+      .level0 = 0,
+      .duration0 = reset_ticks,
+      .level1 = 0,
+      .duration1 = reset_ticks,
+  };
+  *ret_encoder = &led_encoder->base;
+  return ESP_OK;
 err:
-    if (led_encoder) {
-        if (led_encoder->bytes_encoder) {
-            rmt_del_encoder(led_encoder->bytes_encoder);
-        }
-        if (led_encoder->copy_encoder) {
-            rmt_del_encoder(led_encoder->copy_encoder);
-        }
-        free(led_encoder);
+  if (led_encoder) {
+    if (led_encoder->bytes_encoder) {
+      rmt_del_encoder(led_encoder->bytes_encoder);
     }
-    return ret;
+    if (led_encoder->copy_encoder) {
+      rmt_del_encoder(led_encoder->copy_encoder);
+    }
+    free(led_encoder);
+  }
+  return ret;
 }

--- a/src/ws2812_control.c
+++ b/src/ws2812_control.c
@@ -1,35 +1,36 @@
 #include "ws2812_control.h"
 #include "driver/rmt_tx.h"
 #include "driver/rmt_types.h"
-#include "led_strip_encoder.h"
-#include "esp_err.h"
 #include "esp_check.h"
+#include "esp_err.h"
 #include "freertos/FreeRTOS.h"
+#include "led_strip_encoder.h"
 
 // Configure these based on your project needs using menuconfig ********
-#define LED_RMT_TX_CHANNEL		CONFIG_WS2812_LED_RMT_TX_CHANNEL
-#define LED_RMT_TX_GPIO			CONFIG_WS2812_LED_RMT_TX_GPIO
+#define LED_RMT_TX_CHANNEL CONFIG_WS2812_LED_RMT_TX_CHANNEL
+#define LED_RMT_TX_GPIO CONFIG_WS2812_LED_RMT_TX_GPIO
 // ****************************************************
 
-
 #if CONFIG_WS2812_LED_TYPE_RGB
-#define BITS_PER_LED_CMD	24
+#define BITS_PER_LED_CMD 24
 #elif CONFIG_WS2812_LED_TYPE_RGBW
-#define BITS_PER_LED_CMD	32
+#define BITS_PER_LED_CMD 32
 #endif
 
-#define LED_BUFFER_ITEMS	(NUM_LEDS * BITS_PER_LED_CMD)
+#define LED_BUFFER_ITEMS (NUM_LEDS * BITS_PER_LED_CMD)
 
-// These values are determined by measuring pulse timing with logic analyzer and adjusting to match datasheet. 
-#define T0H	CONFIG_WS2812_T0H  // 0 bit high time
-#define T1H	CONFIG_WS2812_T1H  // 1 bit high time
-#define T0L	CONFIG_WS2812_T0L  // low time for either bit
-#define T1L	CONFIG_WS2812_T1L
+// These values are determined by measuring pulse timing with logic analyzer and
+// adjusting to match datasheet.
+#define T0H CONFIG_WS2812_T0H // 0 bit high time
+#define T1H CONFIG_WS2812_T1H // 1 bit high time
+#define T0L CONFIG_WS2812_T0L // low time for either bit
+#define T1L CONFIG_WS2812_T1L
 
 // Tag for log messages
 static const char *TAG = "NeoPixel WS2812 Driver";
 
-// This is the buffer which the hw peripheral will access while pulsing the output pin
+// This is the buffer which the hw peripheral will access while pulsing the
+// output pin
 static rmt_symbol_word_t led_data_buffer[LED_BUFFER_ITEMS];
 static gpio_num_t s_gpio = LED_RMT_TX_GPIO;
 static rmt_channel_handle_t s_handle = NULL;
@@ -55,8 +56,7 @@ static void setupRmtDataBuffer(struct led_state new_state);
  * @param channel  RMT channel used for transmission.
  * @return ESP_OK on success or an ESP-IDF error code.
  */
-esp_err_t ws2812ControlInit(gpio_num_t gpio_num, int channel)
-{
+esp_err_t ws2812ControlInit(gpio_num_t gpio_num, int channel) {
   (void)channel;
   s_gpio = gpio_num;
 
@@ -66,23 +66,17 @@ esp_err_t ws2812ControlInit(gpio_num_t gpio_num, int channel)
   tx_cfg.mem_block_symbols = 64;
   tx_cfg.resolution_hz = 10 * 1000 * 1000;
   tx_cfg.trans_queue_depth = 1;
-  ESP_RETURN_ON_ERROR(
-    rmt_new_tx_channel(&tx_cfg, &s_handle),
-    TAG,
-    "Failed to create RMT channel");
+  ESP_RETURN_ON_ERROR(rmt_new_tx_channel(&tx_cfg, &s_handle), TAG,
+                      "Failed to create RMT channel");
 
   led_strip_encoder_config_t enc_cfg = {
-    .resolution = tx_cfg.resolution_hz,
+      .resolution = tx_cfg.resolution_hz,
   };
-  ESP_RETURN_ON_ERROR(
-    rmt_new_led_strip_encoder(&enc_cfg, &s_encoder),
-    TAG,
-    "Failed to create LED encoder");
+  ESP_RETURN_ON_ERROR(rmt_new_led_strip_encoder(&enc_cfg, &s_encoder), TAG,
+                      "Failed to create LED encoder");
 
-  ESP_RETURN_ON_ERROR(
-    rmt_enable(s_handle),
-    TAG,
-    "Failed to enable RMT channel");
+  ESP_RETURN_ON_ERROR(rmt_enable(s_handle), TAG,
+                      "Failed to enable RMT channel");
 
   return ESP_OK;
 }
@@ -96,36 +90,27 @@ esp_err_t ws2812ControlInit(gpio_num_t gpio_num, int channel)
  * @param new_state Desired LED colours.
  * @return ESP_OK on success or an ESP-IDF error code.
  */
-esp_err_t ws2812WriteLeds(struct led_state new_state)
-{
+esp_err_t ws2812WriteLeds(struct led_state new_state) {
   setupRmtDataBuffer(new_state);
   rmt_transmit_config_t tx_cfg = {};
   tx_cfg.loop_count = 0;
-  ESP_RETURN_ON_ERROR(
-    rmt_transmit(s_handle, s_encoder, led_data_buffer,
-                 sizeof(led_data_buffer), &tx_cfg),
-    TAG,
-    "Failed to transmit LED data");
-  ESP_RETURN_ON_ERROR(
-    rmt_tx_wait_all_done(s_handle, portMAX_DELAY),
-    TAG,
-    "Failed waiting for RMT done");
+  ESP_RETURN_ON_ERROR(rmt_transmit(s_handle, s_encoder, led_data_buffer,
+                                   sizeof(led_data_buffer), &tx_cfg),
+                      TAG, "Failed to transmit LED data");
+  ESP_RETURN_ON_ERROR(rmt_tx_wait_all_done(s_handle, portMAX_DELAY), TAG,
+                      "Failed waiting for RMT done");
 
   return ESP_OK;
 }
 
-void ws2812SetBrightness(uint8_t brightness)
-{
-  s_brightness = brightness;
-}
+void ws2812SetBrightness(uint8_t brightness) { s_brightness = brightness; }
 
 /**
  * @brief Convert colour values into RMT items for transmission.
  *
  * @param new_state Colours to send.
  */
-static void setupRmtDataBuffer(struct led_state new_state)
-{
+static void setupRmtDataBuffer(struct led_state new_state) {
   for (uint32_t led = 0; led < NUM_LEDS; led++) {
     uint32_t color = new_state.leds[led];
 #if CONFIG_WS2812_LED_TYPE_RGBW
@@ -149,10 +134,14 @@ static void setupRmtDataBuffer(struct led_state new_state)
     for (uint32_t bit = 0; bit < BITS_PER_LED_CMD; bit++) {
       uint32_t bit_is_set = bits_to_send & mask;
       led_data_buffer[(led * BITS_PER_LED_CMD) + bit] =
-          bit_is_set ? (rmt_symbol_word_t){.duration0 = T1H, .level0 = 1,
-                                           .duration1 = T1L, .level1 = 0}
-                     : (rmt_symbol_word_t){.duration0 = T0H, .level0 = 1,
-                                           .duration1 = T0L, .level1 = 0};
+          bit_is_set ? (rmt_symbol_word_t){.duration0 = T1H,
+                                           .level0 = 1,
+                                           .duration1 = T1L,
+                                           .level1 = 0}
+                     : (rmt_symbol_word_t){.duration0 = T0H,
+                                           .level0 = 1,
+                                           .duration1 = T0L,
+                                           .level1 = 0};
       mask >>= 1;
     }
   }

--- a/src/ws2812_cpp.cpp
+++ b/src/ws2812_cpp.cpp
@@ -3,112 +3,94 @@
 
 #ifdef __cplusplus
 
-WS2812Strip::WS2812Strip(gpio_num_t gpio,
-                         int channel,
-                         uint32_t numLeds,
+WS2812Strip::WS2812Strip(gpio_num_t gpio, int channel, uint32_t numLeds,
 #if CONFIG_WS2812_LED_TYPE_RGBW
                          LedType type,
 #else
                          LedType type,
 #endif
-                         uint16_t t0h,
-                         uint16_t t1h,
-                         uint16_t t0l,
-                         uint16_t t1l,
+                         uint16_t t0h, uint16_t t1h, uint16_t t0l, uint16_t t1l,
                          uint8_t brightness)
     : m_pixels(numLeds, 0),
       m_buffer(numLeds * (type == LedType::RGBW ? 32 : 24)),
       m_rmt(gpio, 10'000'000, 64, false, 4, RMT_CLK_SRC_DEFAULT, channel),
-      m_gpio(gpio),
-      m_channel(channel),
-      m_type(type),
-      m_t0h(t0h),
-      m_t1h(t1h),
-      m_t0l(t0l),
-      m_t1l(t1l),
-      m_brightness(brightness),
-      m_numLeds(numLeds)
-{}
-
-esp_err_t WS2812Strip::begin()
-{
-    return ESP_OK; // channel already active in constructor
+      m_gpio(gpio), m_channel(channel), m_type(type), m_t0h(t0h), m_t1h(t1h),
+      m_t0l(t0l), m_t1l(t1l), m_brightness(brightness), m_numLeds(numLeds) {
 }
 
-void WS2812Strip::setPixel(uint32_t index, uint32_t rgbw)
-{
-    if (index < m_numLeds) {
-        m_pixels[index] = rgbw;
-    }
+esp_err_t WS2812Strip::begin() {
+  return ESP_OK; // channel already active in constructor
 }
 
-uint32_t WS2812Strip::length() const
-{
-    return m_numLeds;
+void WS2812Strip::setPixel(uint32_t index, uint32_t rgbw) {
+  if (index < m_numLeds) {
+    m_pixels[index] = rgbw;
+  }
 }
 
-esp_err_t WS2812Strip::show()
-{
-    uint32_t bitsPerLed = (m_type == LedType::RGBW) ? 32 : 24;
-    for (uint32_t led = 0; led < m_numLeds; ++led) {
-        uint32_t color = m_pixels[led];
-        uint8_t r = (color >> 16) & 0xFF;
-        uint8_t g = (color >> 8) & 0xFF;
-        uint8_t b = color & 0xFF;
-        uint32_t bits = 0;
+uint32_t WS2812Strip::length() const { return m_numLeds; }
 
-        r = (r * m_brightness) / 255;
-        g = (g * m_brightness) / 255;
-        b = (b * m_brightness) / 255;
+esp_err_t WS2812Strip::show() {
+  uint32_t bitsPerLed = (m_type == LedType::RGBW) ? 32 : 24;
+  for (uint32_t led = 0; led < m_numLeds; ++led) {
+    uint32_t color = m_pixels[led];
+    uint8_t r = (color >> 16) & 0xFF;
+    uint8_t g = (color >> 8) & 0xFF;
+    uint8_t b = color & 0xFF;
+    uint32_t bits = 0;
 
-        if (m_type == LedType::RGBW) {
-            uint8_t w = (color >> 24) & 0xFF;
-            w = (w * m_brightness) / 255;
-            bits = (w << 24) | (r << 16) | (g << 8) | b;
-        } else {
-            bits = (r << 16) | (g << 8) | b;
-        }
+    r = (r * m_brightness) / 255;
+    g = (g * m_brightness) / 255;
+    b = (b * m_brightness) / 255;
 
-        uint32_t mask = 1U << (bitsPerLed - 1);
-        for (uint32_t bit = 0; bit < bitsPerLed; ++bit) {
-            bool set = bits & mask;
-            m_buffer[led * bitsPerLed + bit] =
-                set ? (rmt_symbol_word_t){.duration0 = (uint16_t)m_t1h, .level0 = 1,
-                                          .duration1 = (uint16_t)m_t1l, .level1 = 0}
-                    : (rmt_symbol_word_t){.duration0 = (uint16_t)m_t0h, .level0 = 1,
-                                          .duration1 = (uint16_t)m_t0l, .level1 = 0};
-            mask >>= 1;
-        }
-    }
-
-    return m_rmt.transmit(m_buffer.data(), m_numLeds * bitsPerLed);
-}
-
-void WS2812Strip::setBrightness(uint8_t value)
-{
-    m_brightness = value;
-}
-
-void WS2812Strip::setTimings(uint16_t t0h, uint16_t t1h, uint16_t t0l, uint16_t t1l)
-{
-    m_t0h = t0h;
-    m_t1h = t1h;
-    m_t0l = t0l;
-    m_t1l = t1l;
-}
-
-uint32_t WS2812Strip::colorWheel(uint8_t pos)
-{
-    pos = 255 - pos;
-    if (pos < 85) {
-        return ((255 - pos * 3) << 16) | (0 << 8) | (pos * 3);
-    } else if (pos < 170) {
-        pos -= 85;
-        return (0 << 16) | ((pos * 3) << 8) | (255 - pos * 3);
+    if (m_type == LedType::RGBW) {
+      uint8_t w = (color >> 24) & 0xFF;
+      w = (w * m_brightness) / 255;
+      bits = (w << 24) | (r << 16) | (g << 8) | b;
     } else {
-        pos -= 170;
-        return ((pos * 3) << 16) | ((255 - pos * 3) << 8) | 0;
+      bits = (r << 16) | (g << 8) | b;
     }
+
+    uint32_t mask = 1U << (bitsPerLed - 1);
+    for (uint32_t bit = 0; bit < bitsPerLed; ++bit) {
+      bool set = bits & mask;
+      m_buffer[led * bitsPerLed + bit] =
+          set ? (rmt_symbol_word_t){.duration0 = (uint16_t)m_t1h,
+                                    .level0 = 1,
+                                    .duration1 = (uint16_t)m_t1l,
+                                    .level1 = 0}
+              : (rmt_symbol_word_t){.duration0 = (uint16_t)m_t0h,
+                                    .level0 = 1,
+                                    .duration1 = (uint16_t)m_t0l,
+                                    .level1 = 0};
+      mask >>= 1;
+    }
+  }
+
+  return m_rmt.transmit(m_buffer.data(), m_numLeds * bitsPerLed);
+}
+
+void WS2812Strip::setBrightness(uint8_t value) { m_brightness = value; }
+
+void WS2812Strip::setTimings(uint16_t t0h, uint16_t t1h, uint16_t t0l,
+                             uint16_t t1l) {
+  m_t0h = t0h;
+  m_t1h = t1h;
+  m_t0l = t0l;
+  m_t1l = t1l;
+}
+
+uint32_t WS2812Strip::colorWheel(uint8_t pos) {
+  pos = 255 - pos;
+  if (pos < 85) {
+    return ((255 - pos * 3) << 16) | (0 << 8) | (pos * 3);
+  } else if (pos < 170) {
+    pos -= 85;
+    return (0 << 16) | ((pos * 3) << 8) | (255 - pos * 3);
+  } else {
+    pos -= 170;
+    return ((pos * 3) << 16) | ((255 - pos * 3) << 8) | 0;
+  }
 }
 
 #endif // __cplusplus

--- a/src/ws2812_effects.cpp
+++ b/src/ws2812_effects.cpp
@@ -6,109 +6,101 @@
 WS2812Animator::WS2812Animator(WS2812Strip &strip, uint32_t virtualLength)
     : m_strip(strip), m_virtualLength(virtualLength) {}
 
-void WS2812Animator::setEffect(Effect effect, uint32_t color)
-{
-    m_effect = effect;
-    m_color = color;
-    m_step = 0;
-    m_dir = 1;
-    m_brightness = 0;
+void WS2812Animator::setEffect(Effect effect, uint32_t color) {
+  m_effect = effect;
+  m_color = color;
+  m_step = 0;
+  m_dir = 1;
+  m_brightness = 0;
 }
 
-void WS2812Animator::setVirtualLength(uint32_t length)
-{
-    m_virtualLength = length;
+void WS2812Animator::setVirtualLength(uint32_t length) {
+  m_virtualLength = length;
 }
 
-void WS2812Animator::setStep(uint16_t step)
-{
-    m_step = step;
-}
+void WS2812Animator::setStep(uint16_t step) { m_step = step; }
 
-uint16_t WS2812Animator::step() const
-{
-    return m_step;
-}
+uint16_t WS2812Animator::step() const { return m_step; }
 
-void WS2812Animator::tick()
-{
-    if (!m_initialized) {
-        if (m_strip.begin() == ESP_OK) {
-            m_initialized = true;
-        } else {
-            return;
-        }
+void WS2812Animator::tick() {
+  if (!m_initialized) {
+    if (m_strip.begin() == ESP_OK) {
+      m_initialized = true;
+    } else {
+      return;
     }
+  }
 
-    uint32_t stripLen = m_strip.length();
-    uint32_t virtLen = m_virtualLength ? m_virtualLength : stripLen;
+  uint32_t stripLen = m_strip.length();
+  uint32_t virtLen = m_virtualLength ? m_virtualLength : stripLen;
 
-    switch (m_effect) {
-    case Effect::SolidColor:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            m_strip.setPixel(i, m_color);
-        }
-        m_strip.show();
-        break;
-
-    case Effect::Rainbow:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            uint32_t vIndex = (virtLen == stripLen) ? i : (i * virtLen / stripLen);
-            uint8_t pos = static_cast<uint8_t>((vIndex * 256 / virtLen + m_step) & 0xFF);
-            m_strip.setPixel(i, WS2812Strip::colorWheel(pos));
-        }
-        m_strip.show();
-        m_step = static_cast<uint16_t>((m_step + 1) & 0xFF);
-        break;
-
-    case Effect::Chase:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            if (((i + m_step) % 3) == 0) {
-                m_strip.setPixel(i, m_color);
-            } else {
-                m_strip.setPixel(i, 0);
-            }
-        }
-        m_strip.show();
-        m_step = static_cast<uint16_t>((m_step + 1) % 3);
-        break;
-
-    case Effect::Blink:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            m_strip.setPixel(i, (m_step & 1) ? m_color : 0);
-        }
-        m_strip.show();
-        m_step++;
-        break;
-
-    case Effect::Breath:
-        m_brightness = (m_step < 256) ? m_step : 511 - m_step;
-        m_strip.setBrightness(m_brightness);
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            m_strip.setPixel(i, m_color);
-        }
-        m_strip.show();
-        m_step = static_cast<uint16_t>((m_step + 4) % 512);
-        break;
-
-    case Effect::Larson:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            m_strip.setPixel(i, (i == m_step) ? m_color : 0);
-        }
-        m_strip.show();
-        if ((m_step == 0 && m_dir < 0) || (m_step == stripLen - 1 && m_dir > 0)) {
-            m_dir = -m_dir;
-        }
-        m_step = static_cast<uint16_t>(m_step + m_dir);
-        break;
-
-    default:
-        for (uint32_t i = 0; i < stripLen; ++i) {
-            m_strip.setPixel(i, 0);
-        }
-        m_strip.show();
-        break;
+  switch (m_effect) {
+  case Effect::SolidColor:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      m_strip.setPixel(i, m_color);
     }
+    m_strip.show();
+    break;
+
+  case Effect::Rainbow:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      uint32_t vIndex = (virtLen == stripLen) ? i : (i * virtLen / stripLen);
+      uint8_t pos =
+          static_cast<uint8_t>((vIndex * 256 / virtLen + m_step) & 0xFF);
+      m_strip.setPixel(i, WS2812Strip::colorWheel(pos));
+    }
+    m_strip.show();
+    m_step = static_cast<uint16_t>((m_step + 1) & 0xFF);
+    break;
+
+  case Effect::Chase:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      if (((i + m_step) % 3) == 0) {
+        m_strip.setPixel(i, m_color);
+      } else {
+        m_strip.setPixel(i, 0);
+      }
+    }
+    m_strip.show();
+    m_step = static_cast<uint16_t>((m_step + 1) % 3);
+    break;
+
+  case Effect::Blink:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      m_strip.setPixel(i, (m_step & 1) ? m_color : 0);
+    }
+    m_strip.show();
+    m_step++;
+    break;
+
+  case Effect::Breath:
+    m_brightness = (m_step < 256) ? m_step : 511 - m_step;
+    m_strip.setBrightness(m_brightness);
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      m_strip.setPixel(i, m_color);
+    }
+    m_strip.show();
+    m_step = static_cast<uint16_t>((m_step + 4) % 512);
+    break;
+
+  case Effect::Larson:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      m_strip.setPixel(i, (i == m_step) ? m_color : 0);
+    }
+    m_strip.show();
+    if ((m_step == 0 && m_dir < 0) || (m_step == stripLen - 1 && m_dir > 0)) {
+      m_dir = -m_dir;
+    }
+    m_step = static_cast<uint16_t>(m_step + m_dir);
+    break;
+
+  default:
+    for (uint32_t i = 0; i < stripLen; ++i) {
+      m_strip.setPixel(i, 0);
+    }
+    m_strip.show();
+    break;
+  }
 }
 
 #endif // __cplusplus

--- a/src/ws2812_multi_animator.cpp
+++ b/src/ws2812_multi_animator.cpp
@@ -2,50 +2,48 @@
 
 #ifdef __cplusplus
 
-WS2812MultiAnimator::WS2812MultiAnimator(const std::vector<WS2812Strip*>& strips,
-                                         bool unified,
-                                         bool sync)
-    : m_sync(sync)
-{
-    uint32_t maxLen = 0;
-    for (auto* s : strips) {
-        if (s && s->length() > maxLen) {
-            maxLen = s->length();
-        }
+WS2812MultiAnimator::WS2812MultiAnimator(
+    const std::vector<WS2812Strip *> &strips, bool unified, bool sync)
+    : m_sync(sync) {
+  uint32_t maxLen = 0;
+  for (auto *s : strips) {
+    if (s && s->length() > maxLen) {
+      maxLen = s->length();
     }
-    for (auto* s : strips) {
-        if (!s) continue;
-        m_animators.emplace_back(*s, unified ? maxLen : 0);
-    }
+  }
+  for (auto *s : strips) {
+    if (!s)
+      continue;
+    m_animators.emplace_back(*s, unified ? maxLen : 0);
+  }
 }
 
-void WS2812MultiAnimator::setEffect(WS2812Animator::Effect eff, uint32_t color)
-{
-    for (auto& a : m_animators) {
-        a.setEffect(eff, color);
-    }
+void WS2812MultiAnimator::setEffect(WS2812Animator::Effect eff,
+                                    uint32_t color) {
+  for (auto &a : m_animators) {
+    a.setEffect(eff, color);
+  }
 }
 
-void WS2812MultiAnimator::setEffect(size_t idx, WS2812Animator::Effect eff, uint32_t color)
-{
-    if (idx < m_animators.size()) {
-        m_animators[idx].setEffect(eff, color);
-    }
+void WS2812MultiAnimator::setEffect(size_t idx, WS2812Animator::Effect eff,
+                                    uint32_t color) {
+  if (idx < m_animators.size()) {
+    m_animators[idx].setEffect(eff, color);
+  }
 }
 
-void WS2812MultiAnimator::tick()
-{
-    if (m_sync) {
-        for (auto& a : m_animators) {
-            a.setStep(m_step);
-        }
+void WS2812MultiAnimator::tick() {
+  if (m_sync) {
+    for (auto &a : m_animators) {
+      a.setStep(m_step);
     }
-    for (auto& a : m_animators) {
-        a.tick();
-    }
-    if (m_sync && !m_animators.empty()) {
-        m_step = m_animators.front().step();
-    }
+  }
+  for (auto &a : m_animators) {
+    a.tick();
+  }
+  if (m_sync && !m_animators.empty()) {
+    m_step = m_animators.front().step();
+  }
 }
 
 #endif // __cplusplus


### PR DESCRIPTION
## Summary
- remove all generated HTML documentation
- ignore `docs/` so CI can generate docs without committing them
- clarify README instructions for generating docs

## Testing
- `clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp`
- `doxygen Doxyfile`


------
https://chatgpt.com/codex/tasks/task_e_684cae33d3748328b6b6e15ce49de353