### PR TITLE
Move RMT wrapper into ws2812 namespace

### DIFF
--- a/include/rmt_wrapper.hpp
+++ b/include/rmt_wrapper.hpp
@@ -24,12 +24,12 @@
  * ### Minimum snippet
  * ```cpp
  * #include "rmt_wrapper.hpp"
- * using namespace hf;
+ * using namespace ws2812;
  *
  * extern "C" void app_main(void)
  * {
  *     static constexpr gpio_num_t LED_PIN = GPIO_NUM_8;  // verified GPIO for
- * ESP32‑C6 hf::RmtTx tx(LED_PIN, 40'000'000);                 // 25 ns
+ * ESP32‑C6 ws2812::RmtTx tx(LED_PIN, 40'000'000);             // 25 ns
  * resolution
  *
  *     uint8_t grb[3] = {0x00, 0xFF, 0x00};               // green pixel
@@ -63,7 +63,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
-namespace hf {
+namespace ws2812 {
 
 namespace detail {
 [[nodiscard]] inline esp_err_t log_if_error(esp_err_t err, const char *tag, const char *msg) {
@@ -314,4 +314,4 @@ private:
   rmt_receive_config_t _rcv_cfg = {};
 };
 
-} // namespace hf
+} // namespace ws2812

--- a/include/ws2812_cpp.hpp
+++ b/include/ws2812_cpp.hpp
@@ -95,7 +95,7 @@ public:
 private:
   std::vector<uint32_t> m_pixels;
   std::vector<rmt_symbol_word_t> m_buffer;
-  hf::RmtTx m_rmt;
+  ws2812::RmtTx m_rmt;
   gpio_num_t m_gpio;
   int m_channel;
   LedType m_type;


### PR DESCRIPTION
## Summary
- namespace change: `hf` -> `ws2812`
- update snippet comment to reflect new namespace
- adjust `WS2812Strip` to use `ws2812::RmtTx`

## Testing
- `clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp`
- `cmake -S . -B build` *(fails: Unknown CMake command `idf_component_register`)*
