### PR TITLE
Add IDF component manifest

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,17 @@
+version: "0.1.0"
+description: "ESP32 RMT based WS2812/NeoPixel driver"
+url: https://github.com/N3b3x/hf-ws2812-rmt-driver
+license: GPL-3.0-or-later
+dependencies:
+  idf: ">=5.0"
+  driver: "*"
+  freertos: "*"
+targets:
+  - esp32
+  - esp32s2
+  - esp32s3
+  - esp32c3
+  - esp32c6
+  - esp32h2
+examples:
+  - path: example


### PR DESCRIPTION
## Summary
- add `idf_component.yml` for automatic discovery by the IDF Component Manager

## Testing
- `clang-format --dry-run --Werror include/*.[ch]pp include/*.h src/*.[ch] src/*.cpp example/main/*.cpp`
